### PR TITLE
Change to syncdc command for dctool 7.0

### DIFF
--- a/src/main/java/org/arachna/netweaver/tools/dc/SyncDcCommandTemplate.java
+++ b/src/main/java/org/arachna/netweaver/tools/dc/SyncDcCommandTemplate.java
@@ -17,7 +17,7 @@ enum SyncDcCommandTemplate {
     /**
      * Template for NW 7.0.
      */
-    V70("syncdc -s %s -n %s -v %s -m inactive -y;", "syncdc -s %s -n %s -v %s -m archive -u;",
+    V70("syncdc -s %s -n %s -v %s -m inactive -y;", "syncdc -s %s -n %s -v %s -m archive --syncused;",
         "syncalldcs -s %s -m archive;", "syncalldcs -s %s -m inactive;", "unsyncdc -s %s -n %s -v %s;"),
 
     /**

--- a/src/test/java/org/arachna/netweaver/tools/dc/SyncDevelopmentComponentsCommandBuilderTest.java
+++ b/src/test/java/org/arachna/netweaver/tools/dc/SyncDevelopmentComponentsCommandBuilderTest.java
@@ -144,7 +144,7 @@ public class SyncDevelopmentComponentsCommandBuilderTest {
         final List<String> commands = builder.executeInternal();
         assertThat(commands.size(), equalTo(1));
         final String expected =
-            String.format("syncdc -s %s -n %s -v %s -m archive -u;", compartment.getName(), library.getName(),
+            String.format("syncdc -s %s -n %s -v %s -m archive --syncused;", compartment.getName(), library.getName(),
                 library.getVendor());
         assertThat(commands.get(0), equalTo(expected));
     }


### PR DESCRIPTION
The syntax of the syncdc command for dctool 7.0 is not used correctly.

At this moment -u is used but it should be --syncused.
