### PR TITLE
Buildspace can contain minus sign

### DIFF
--- a/src/main/java/org/arachna/netweaver/tools/cbs/BuildSpaceParser.java
+++ b/src/main/java/org/arachna/netweaver/tools/cbs/BuildSpaceParser.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
  * @author Dirk Weigenand
  */
 final class BuildSpaceParser {
+ 
     /**
      * Regular expression to match output of the 'listbuildspaces' cbstool
      * command.


### PR DESCRIPTION
Adjusting code so you can see buildspaces with a minus sign in the dropdownbox when configuring a NWDI project.
